### PR TITLE
Fix readme example file-path parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ jobs:
       - uses: iamsauravsharma/create-dotenv@v2.0.0
         with:
           input-prefix: 'ENV_KEY_' # Optional (default: '')
-          file-name: 'tests/development.env' # Optional (default : '.env')
+          file-path: 'tests/development.env' # Optional (default : '.env')
           output-prefix: 'OUTPUT_' # Optional (default: '')
         env: # env available for only this steps
           IS_SERVER: true


### PR DESCRIPTION
This baited me D:

There also was a bug. If i omitted the `input-prefix` , it put the whole environment of the runtime node into that newly created env-file, in addition to any parameters i defined. Might look into that later.

But otherwise this has worked fine :+1: